### PR TITLE
Increasing limit to 200 on the environments API Call

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ httpListener:
   anypointplatform:
     host: "anypoint.mulesoft.com"
     csorgpath: "/accounts/api/cs/organizations/"
-    environments: "/environments?&limit=100"
+    environments: "/environments?&limit=200"
   armuiapplications: "/armui/api/v1/applications"
   ch1applications: "/cloudhub/api/organizations/"
   exchangebasepath: "exchange/api/v2/assets/"


### PR DESCRIPTION
The API default response limit is 25, altered the limit to 200. Current infra [limits](https://docs.mulesoft.com/access-management/troubleshooting-anypoint-platform-access#access-management-limits) creation of more than 150 environments